### PR TITLE
Implement an exact query example

### DIFF
--- a/query-exact.ts
+++ b/query-exact.ts
@@ -8,10 +8,10 @@ async function queryCollection() {
     const movies = await stash.loadCollection(movieSchema)
 
     let queryResult = await movies.query(
-      movie => movie.title.match("life"),
+      movie => movie.exactTitle.eq("Lifelines"),
       { limit: 10 }
     )
-    displayResults(queryResult, "Match: 'life'")
+    displayResults(queryResult, "Exact title: 'Lifelines'")
 
   } catch (err) {
     console.error(err)


### PR DESCRIPTION
Also modify the term of the match query example so it finds results in our
example data set.