### PR TITLE
Update data types in example schema

### DIFF
--- a/movies.schema.json
+++ b/movies.schema.json
@@ -1,8 +1,8 @@
 {
   "type": {
     "title": "string",
-    "runningTime": "number",
-    "year": "number"
+    "runningTime": "float64",
+    "year": "float64"
   },
   "indexes": {
     "exactTitle": { "kind": "exact", "field": "title" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@cipherstash/stashjs": "^0.3.8",
+        "@cipherstash/stashjs": "^0.3.10",
         "@types/faker": "^5.5.7",
         "@types/node": "16.0.1",
         "@types/uuid": "^8.3.2",
@@ -1022,9 +1022,9 @@
       }
     },
     "node_modules/@cipherstash/stashjs": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@cipherstash/stashjs/-/stashjs-0.3.8.tgz",
-      "integrity": "sha512-qrXRF1ANWOCFRBO9K0JYI0q6OruxrlwwxjPfqAQC0T2WmmuhfQPZv6m+5ob9TbnsafCB3zTicheWKCiy60I+uw==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@cipherstash/stashjs/-/stashjs-0.3.10.tgz",
+      "integrity": "sha512-nFtc8u7m/6auE6FCenrHqQ+ep43XKjXiHCQt8Bbgl6a9ZM4WhuTfaR3mXpKPnr80SzUpqvnd+lXurmPbfWcqBQ==",
       "dependencies": {
         "@aws-crypto/client-node": "^2.2.0",
         "@aws-sdk/client-kms": "^3.38.0",
@@ -3052,9 +3052,9 @@
       }
     },
     "@cipherstash/stashjs": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@cipherstash/stashjs/-/stashjs-0.3.8.tgz",
-      "integrity": "sha512-qrXRF1ANWOCFRBO9K0JYI0q6OruxrlwwxjPfqAQC0T2WmmuhfQPZv6m+5ob9TbnsafCB3zTicheWKCiy60I+uw==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@cipherstash/stashjs/-/stashjs-0.3.10.tgz",
+      "integrity": "sha512-nFtc8u7m/6auE6FCenrHqQ+ep43XKjXiHCQt8Bbgl6a9ZM4WhuTfaR3mXpKPnr80SzUpqvnd+lXurmPbfWcqBQ==",
       "requires": {
         "@aws-crypto/client-node": "^2.2.0",
         "@aws-sdk/client-kms": "^3.38.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/cipherstash/stashjs-examples#readme",
   "dependencies": {
-    "@cipherstash/stashjs": "^0.3.8",
+    "@cipherstash/stashjs": "^0.3.10",
     "@types/faker": "^5.5.7",
     "@types/node": "16.0.1",
     "@types/uuid": "^8.3.2",


### PR DESCRIPTION
Updates the example schema.json to use the updated index data types https://github.com/cipherstash/platform/pull/860

This PR is dependant on latest stashJS being published.