### PR TITLE
Bump StashJS to v0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@cipherstash/stashjs": "^0.3.10",
+        "@cipherstash/stashjs": "^0.4.1",
         "@types/faker": "^5.5.7",
         "@types/node": "16.0.1",
         "@types/uuid": "^8.3.2",
@@ -1022,21 +1022,21 @@
       }
     },
     "node_modules/@cipherstash/stashjs": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@cipherstash/stashjs/-/stashjs-0.3.10.tgz",
-      "integrity": "sha512-nFtc8u7m/6auE6FCenrHqQ+ep43XKjXiHCQt8Bbgl6a9ZM4WhuTfaR3mXpKPnr80SzUpqvnd+lXurmPbfWcqBQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@cipherstash/stashjs/-/stashjs-0.4.1.tgz",
+      "integrity": "sha512-8YUvsYty7GgzWM2FlSJbSmDyGT6D31vmCze127ygqqlYkpxe/cJCsus2FudVngVLVUOodSKd+ruFdNOrXij4lQ==",
       "dependencies": {
         "@aws-crypto/client-node": "^2.2.0",
         "@aws-sdk/client-kms": "^3.38.0",
         "@aws-sdk/client-sts": "^3.34.0",
         "@cfworker/json-schema": "^1.12.1",
         "@cipherstash/ore-rs": "^0.5.1",
-        "@cipherstash/stashjs-grpc": "0.3.1",
+        "@cipherstash/stashjs-grpc": "0.3.4",
         "@grpc/grpc-js": "^1.5.5",
         "@grpc/proto-loader": "^0.6.2",
         "@types/stringify-object": "^3.3.1",
         "aws-sdk": "^2.918.0",
-        "axios": "0.26.1",
+        "axios": "0.27.2",
         "bson": "^4.4.0",
         "fp-ts": "^2.11.8",
         "io-ts": "^2.2.16",
@@ -1056,9 +1056,9 @@
       }
     },
     "node_modules/@cipherstash/stashjs-grpc": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@cipherstash/stashjs-grpc/-/stashjs-grpc-0.3.1.tgz",
-      "integrity": "sha512-waZoDk6nDumI9FSSR6uYZ3I6qNiRoPnD9TiR/JWn3bXmMETdv1wqSW5u210N5e18yyuV1vZIxgJZ5ocorSRqbA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cipherstash/stashjs-grpc/-/stashjs-grpc-0.3.4.tgz",
+      "integrity": "sha512-KcJI9cCtZR7xSIjfkIHrpqVs65/z/CyeElcMuVYoGXZxeJmeF+se8scTUBEKzJ2Go4YNpwfYl9zQZYbFJzVZCA==",
       "dependencies": {
         "@grpc/grpc-js": "^1.5.5",
         "@grpc/proto-loader": "^0.6.2"
@@ -1083,9 +1083,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.5.10.tgz",
-      "integrity": "sha512-++oAubX/7rJzlqH0ShyzDENNNDHYrlttdc3NM40KlaVQDcgGqQknuPoavmyTC+oNUDyxPCX5dHceKhfcgN3tiw==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
+      "integrity": "sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==",
       "dependencies": {
         "@grpc/proto-loader": "^0.6.4",
         "@types/node": ">=12.12.47"
@@ -1095,9 +1095,9 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.9.tgz",
-      "integrity": "sha512-UlcCS8VbsU9d3XTXGiEVFonN7hXk+oMXZtoHHG2oSA1/GcDP1q6OUgs20PzHDGizzyi8ufGSUDlk3O2NyY7leg==",
+      "version": "0.6.12",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.12.tgz",
+      "integrity": "sha512-filTVbETFnxb9CyRX98zN18ilChTuf/C5scZ2xyaOTp0EHGq0/ufX8rjqXUcSb1Gpv7eZq4M2jDvbh9BogKnrg==",
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
@@ -1180,9 +1180,9 @@
       "integrity": "sha512-uCx6mP3UY5SIO14XlspxsGjgaemrxpssJI0Ol+GfhxtcKpv9pgRZYsS4eeKeHVLje6Qtc8lGszuBI461+gVZBA=="
     },
     "node_modules/@types/long": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/lru-cache": {
       "version": "5.1.1",
@@ -1263,6 +1263,11 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
       "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "node_modules/aws-sdk": {
       "version": "2.1094.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1094.0.tgz",
@@ -1292,11 +1297,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/base64-js": {
@@ -1440,6 +1446,17 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/csv-parse": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.0.4.tgz",
@@ -1451,6 +1468,14 @@
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/duplexify": {
@@ -1542,9 +1567,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
       "funding": [
         {
           "type": "individual",
@@ -1558,6 +1583,19 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fp-ts": {
@@ -1762,6 +1800,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -3052,21 +3109,21 @@
       }
     },
     "@cipherstash/stashjs": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@cipherstash/stashjs/-/stashjs-0.3.10.tgz",
-      "integrity": "sha512-nFtc8u7m/6auE6FCenrHqQ+ep43XKjXiHCQt8Bbgl6a9ZM4WhuTfaR3mXpKPnr80SzUpqvnd+lXurmPbfWcqBQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@cipherstash/stashjs/-/stashjs-0.4.1.tgz",
+      "integrity": "sha512-8YUvsYty7GgzWM2FlSJbSmDyGT6D31vmCze127ygqqlYkpxe/cJCsus2FudVngVLVUOodSKd+ruFdNOrXij4lQ==",
       "requires": {
         "@aws-crypto/client-node": "^2.2.0",
         "@aws-sdk/client-kms": "^3.38.0",
         "@aws-sdk/client-sts": "^3.34.0",
         "@cfworker/json-schema": "^1.12.1",
         "@cipherstash/ore-rs": "^0.5.1",
-        "@cipherstash/stashjs-grpc": "0.3.1",
+        "@cipherstash/stashjs-grpc": "0.3.4",
         "@grpc/grpc-js": "^1.5.5",
         "@grpc/proto-loader": "^0.6.2",
         "@types/stringify-object": "^3.3.1",
         "aws-sdk": "^2.918.0",
-        "axios": "0.26.1",
+        "axios": "0.27.2",
         "bson": "^4.4.0",
         "fp-ts": "^2.11.8",
         "io-ts": "^2.2.16",
@@ -3083,9 +3140,9 @@
       }
     },
     "@cipherstash/stashjs-grpc": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@cipherstash/stashjs-grpc/-/stashjs-grpc-0.3.1.tgz",
-      "integrity": "sha512-waZoDk6nDumI9FSSR6uYZ3I6qNiRoPnD9TiR/JWn3bXmMETdv1wqSW5u210N5e18yyuV1vZIxgJZ5ocorSRqbA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cipherstash/stashjs-grpc/-/stashjs-grpc-0.3.4.tgz",
+      "integrity": "sha512-KcJI9cCtZR7xSIjfkIHrpqVs65/z/CyeElcMuVYoGXZxeJmeF+se8scTUBEKzJ2Go4YNpwfYl9zQZYbFJzVZCA==",
       "requires": {
         "@grpc/grpc-js": "^1.5.5",
         "@grpc/proto-loader": "^0.6.2"
@@ -3107,18 +3164,18 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.5.10.tgz",
-      "integrity": "sha512-++oAubX/7rJzlqH0ShyzDENNNDHYrlttdc3NM40KlaVQDcgGqQknuPoavmyTC+oNUDyxPCX5dHceKhfcgN3tiw==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
+      "integrity": "sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==",
       "requires": {
         "@grpc/proto-loader": "^0.6.4",
         "@types/node": ">=12.12.47"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.9.tgz",
-      "integrity": "sha512-UlcCS8VbsU9d3XTXGiEVFonN7hXk+oMXZtoHHG2oSA1/GcDP1q6OUgs20PzHDGizzyi8ufGSUDlk3O2NyY7leg==",
+      "version": "0.6.12",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.12.tgz",
+      "integrity": "sha512-filTVbETFnxb9CyRX98zN18ilChTuf/C5scZ2xyaOTp0EHGq0/ufX8rjqXUcSb1Gpv7eZq4M2jDvbh9BogKnrg==",
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
@@ -3195,9 +3252,9 @@
       "integrity": "sha512-uCx6mP3UY5SIO14XlspxsGjgaemrxpssJI0Ol+GfhxtcKpv9pgRZYsS4eeKeHVLje6Qtc8lGszuBI461+gVZBA=="
     },
     "@types/long": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/lru-cache": {
       "version": "5.1.1",
@@ -3270,6 +3327,11 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
       "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "aws-sdk": {
       "version": "2.1094.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1094.0.tgz",
@@ -3294,11 +3356,12 @@
       }
     },
     "axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "requires": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "base64-js": {
@@ -3410,6 +3473,14 @@
         "text-hex": "1.0.x"
       }
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "csv-parse": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.0.4.tgz",
@@ -3419,6 +3490,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "duplexify": {
       "version": "4.1.2",
@@ -3493,9 +3569,19 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "fp-ts": {
       "version": "2.11.9",
@@ -3655,6 +3741,19 @@
       "requires": {
         "is-what": "^3.14.1",
         "ts-toolbelt": "^9.6.0"
+      }
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
       }
     },
     "minimalistic-assert": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/cipherstash/stashjs-examples#readme",
   "dependencies": {
-    "@cipherstash/stashjs": "^0.3.10",
+    "@cipherstash/stashjs": "^0.4.1",
     "@types/faker": "^5.5.7",
     "@types/node": "16.0.1",
     "@types/uuid": "^8.3.2",


### PR DESCRIPTION
This PR bumps StashJS to the latest version (0.4.1).